### PR TITLE
feat: ユーザーの新規登録時の招待コード保存処理を追加

### DIFF
--- a/02_users_controller.php
+++ b/02_users_controller.php
@@ -7,6 +7,8 @@ class UsersController extends AppControlelr
   public function register()
   {
     $userData = $this->params['data']['user'];
+    $userData['invitationCode'] = $this->params['data']['invitationCode'];
+
     $service = new UserService($this);
     $user = $service->register($userData);
 

--- a/03_user_service.php
+++ b/03_user_service.php
@@ -23,11 +23,20 @@ class UserService extends AppService
     if ($this->isBlank($userData['name'])) {
       $this->invalidReasons[] = '名前が入力されていません。';
     }
+
     if ($this->isBlank($userData['name'])) {
       $this->invalidReasons[] = 'メールアドレスが入力されていません。';
     } elseif ($this->isInvalidEmail($userData['name'])) {
       $this->invalidReasons[] = 'メールアドレスの形式が正しくありません。';
     }
+
+    if ($this->isBlank($userData['invitationCode'])) {
+      // 処理なし
+      // (招待コードは必須項目ではないため、未指定でもエラーとしない)
+    } elseif ($this->isValidInvitationCode($userData['invitationCode'])) {
+      $this->invalidReasons[] = '招待コードの形式が正しくありません。';
+    }
+
     return count($this->invalidReasons) === 0;
   }
 }


### PR DESCRIPTION
## 修正概要

ユーザー新規登録時のリクエストパラメータ `invitationCode` 追加に伴い、バリデーションおよびDB保存処理を追加

#### リクエスト例

```
[
  'user' => [
    'name' => 'Example太郎',
    'mailaddress' => 'taro@example.com',
  ],
  'invitationCode' => 'H124FHP', // or null
];
```

### 補足

- invitationCodeは `null` の場合もあり
- 招待コードの具体的なバリデーション処理 (`isValidInvitationCode()`) については省略
  - ユーザーが入力ミスなどで無効なコードを入力した場合などに気づけるようにチェックNG時はエラー画面を表示するケースなどが想定される
- invitationCodeカラムは既にユーザーテーブルに追加済み
