### PR TITLE
fix: リクエストによって不正にユーザーデータが書き換えられる問題を修正

### DIFF
--- a/02_users_controller.php
+++ b/02_users_controller.php
@@ -6,8 +6,11 @@ class UsersController extends AppControlelr
 
   public function register()
   {
-    $userData = $this->params['data']['user'];
-    $userData['invitationCode'] = $this->params['data']['invitationCode'];
+    $userData = [];
+    $userData['name'] = $this->params['data']['user']['name'] ?? null;
+    $userData['mailaddress'] = $this->params['data']['user']['mailaddress'] ?? null;
+    $userData['invitationCode'] = $this->params['data']['invitationCode'] ?? null;
+
     $mailMagazinOptedIn = $this->Session->read('mailMagazineOptedIn');
     if (isset($mailMagazinOptedIn)) {
       $userData['mailMagazineOptedIn'] = $mailMagazinOptedIn;


### PR DESCRIPTION
## 概要

リクエストパラメータで name, mailaddress 以外のカラムが指定された場合、そのままDBに登録される可能性があるため、リクエストからサービスに渡すユーザーデータを作成するよう修正しました。

#### 例

ユーザーテーブルにpasswordカラムが存在していると仮定とした場合、param['data']['user']['password']が(不正に)渡された場合